### PR TITLE
Updated Role entity

### DIFF
--- a/src/Pingpong/Trusty/Entities/Role.php
+++ b/src/Pingpong/Trusty/Entities/Role.php
@@ -34,7 +34,7 @@ class Role extends \Eloquent
 		return $this->belongsToMany(Config::get('auth.model'))->withTimestamps();
 	}
 
-	public function has($permission)
+	public function can($permission)
 	{
 		return in_array($permission, array_fetch($this->permissions->toArray(), 'slug'));
 	}


### PR DESCRIPTION
Added a return relationship to the users model (so you can display the number of users within a given role, etc.), and added the `can` method so you can check permissions against a role.

I added these as I needed them for the CMS I am building, and wanted to show a) number of users in each role, and b) wanted to show which roles had access to the admin section.
