### PR TITLE
Fixed roles relationship

### DIFF
--- a/Permission.php
+++ b/Permission.php
@@ -23,6 +23,6 @@ class Permission extends Model
      */
     public function roles()
     {
-        return $this->belongsToMany(config('trusty.model.permission'))->withTimestamps();
+        return $this->belongsToMany(config('trusty.model.role'))->withTimestamps();
     }
 }


### PR DESCRIPTION
I'm pretty sure the roles() belongs to many relationship on the Permission model is pointing to the wrong model. At least this fixed it for me (L5.1).
